### PR TITLE
Fix francetv

### DIFF
--- a/providers/francetv/algolia.go
+++ b/providers/francetv/algolia.go
@@ -179,11 +179,10 @@ func (p *FranceTV) queryAlgolia(ctx context.Context, mr *providers.MatchRequest)
 						continue
 					}
 
-					if len(h.Program.Label) > 0 && !strings.Contains(strings.ToLower(h.Program.Label), mr.Show) {
-						continue
-					}
-
-					if len(h.Program.Label) == 0 && !strings.Contains(strings.ToLower(h.Title), mr.Show) {
+					found := false
+					found = found || strings.Contains(strings.ToLower(h.Program.Label), mr.Show)
+					found = found || strings.Contains(strings.ToLower(h.Title), mr.Show)
+					if !found {
 						continue
 					}
 


### PR DESCRIPTION
Fixes #34:
- Correct the way to peek DASH stream url
- Better ffmpeg log parser for returning errors to caller
- Add watchdog to ffmpeg to detect frame receive  stalling
